### PR TITLE
Add back button and click away functionality

### DIFF
--- a/public/img/grey-back.svg
+++ b/public/img/grey-back.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 22.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 24 24" style="enable-background:new 0 0 24 24;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#DEDEDE;}
+</style>
+<path class="st0" d="M0,12l9-8v6h15v4H9v6L0,12z"/>
+</svg>

--- a/src/components/home/HomeView.css
+++ b/src/components/home/HomeView.css
@@ -19,7 +19,7 @@
 
 .HomeView .right {
   background: #FFF;
-  padding: 4%;
+  padding: 2.5% 4%;
   width: 34%;
 }
 

--- a/src/components/home/HomeView.js
+++ b/src/components/home/HomeView.js
@@ -20,15 +20,18 @@ class HomeView extends Component {
 
     this.handleSelectEvent = this.handleSelectEvent.bind(this);
     this.handleSelectDay = this.handleSelectDay.bind(this);
+    this.handleClickAway = this.handleClickAway.bind(this);
     this.handleSearch = this.handleSearch.bind(this);
   }
 
   handleSelectEvent(event) {
     if (this.state.event !== null && this.state.event.uid === event.uid) {
+      document.getElementsByClassName("column left")[0].removeEventListener('click', this.handleClickAway, false);
       this.setState({
         event: null
       });
     } else {
+      document.getElementsByClassName("column left")[0].addEventListener('click', this.handleClickAway, false);
       this.setState({ event });
     }
   }
@@ -36,6 +39,13 @@ class HomeView extends Component {
   handleSelectDay(m) {
     this.setState({
       day: m,
+      event: null
+    });
+  }
+
+  handleClickAway(event) {
+    document.getElementsByClassName("column left")[0].removeEventListener('click', this.handleClickAway, false);
+    this.setState({
       event: null
     });
   }
@@ -67,6 +77,7 @@ class HomeView extends Component {
             onSelectDay={this.handleSelectDay}
           />
           <HomeSidebarEventModal
+            onSelectBack={this.handleClickAway}
             event={this.state.event}
           />
         </div>

--- a/src/components/home/feed/HomeFeedEventView.js
+++ b/src/components/home/feed/HomeFeedEventView.js
@@ -19,7 +19,7 @@ class HomeFeedEventView extends Component {
         <p>{this.props.event.location}</p>
         <p className={"description" + (this.props.selected ? " selected" : "")}><br />{this.props.event.description}</p>
       </div>
-    )
+    );
   }
 }
 

--- a/src/components/home/sidebar/HomeSidebarEventModal.css
+++ b/src/components/home/sidebar/HomeSidebarEventModal.css
@@ -29,3 +29,30 @@
   color: #55596B;
   letter-spacing: 0.05em;
 }
+
+.HomeSidebarEventModal .button {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.8em;
+  font-weight: 400;
+  color: #C7C7C7;
+  letter-spacing: 0.08em;
+  background-color: #FAFAFA;
+  padding: 1em 1em;
+  box-shadow: 0 4px 6px 0 rgba(0, 0, 0, 0.03);
+  cursor: pointer;
+}
+
+.HomeSidebarEventModal .button:hover {
+  background-color: #EEEEEE;
+}
+
+.HomeSidebarEventModal .button .left-button {
+  width: 0;
+  height: 0;
+  margin-right: 0.5em;
+  border-top: 5px solid transparent;
+  border-bottom: 5px solid transparent;
+  border-right: 8px solid #D8D8D8;
+  cursor: pointer;
+}

--- a/src/components/home/sidebar/HomeSidebarEventModal.css
+++ b/src/components/home/sidebar/HomeSidebarEventModal.css
@@ -31,28 +31,7 @@
 }
 
 .HomeSidebarEventModal .button {
-  display: inline-flex;
-  align-items: center;
-  font-size: 0.8em;
-  font-weight: 400;
-  color: #C7C7C7;
-  letter-spacing: 0.08em;
-  background-color: #FAFAFA;
-  padding: 1em 1em;
-  box-shadow: 0 4px 6px 0 rgba(0, 0, 0, 0.03);
-  cursor: pointer;
-}
-
-.HomeSidebarEventModal .button:hover {
-  background-color: #EEEEEE;
-}
-
-.HomeSidebarEventModal .button .left-button {
-  width: 0;
-  height: 0;
-  margin-right: 0.5em;
-  border-top: 5px solid transparent;
-  border-bottom: 5px solid transparent;
-  border-right: 8px solid #D8D8D8;
+  width: 24px;
+  margin: 5px;
   cursor: pointer;
 }

--- a/src/components/home/sidebar/HomeSidebarEventModal.js
+++ b/src/components/home/sidebar/HomeSidebarEventModal.js
@@ -9,10 +9,7 @@ class HomeSidebarEventModal extends Component {
 
     return (
       <div className="HomeSidebarEventModal">
-        <div className="button" onClick={this.props.onSelectBack}>
-          <div className="left-button" />
-          <p>Back</p>
-        </div>
+        <img className="button" src="/img/grey-back.svg" alt="Back" onClick={this.props.onSelectBack} />
         <h2>{this.props.event.title}</h2>
         <div dangerouslySetInnerHTML={{__html: this.props.event.description}} />
       </div>

--- a/src/components/home/sidebar/HomeSidebarEventModal.js
+++ b/src/components/home/sidebar/HomeSidebarEventModal.js
@@ -9,7 +9,7 @@ class HomeSidebarEventModal extends Component {
 
     return (
       <div className="HomeSidebarEventModal">
-        <div className="button">
+        <div className="button" onClick={this.props.onSelectBack}>
           <div className="left-button" />
           <p>Back</p>
         </div>

--- a/src/components/home/sidebar/HomeSidebarEventModal.js
+++ b/src/components/home/sidebar/HomeSidebarEventModal.js
@@ -9,6 +9,10 @@ class HomeSidebarEventModal extends Component {
 
     return (
       <div className="HomeSidebarEventModal">
+        <div className="button">
+          <div className="left-button" />
+          <p>Back</p>
+        </div>
         <h2>{this.props.event.title}</h2>
         <div dangerouslySetInnerHTML={{__html: this.props.event.description}} />
       </div>


### PR DESCRIPTION
**UI Changes**: Add Back button at top left of right column

**New functionality**: to minimize right column after selecting an event
* Click the back button OR
* Click anywhere in the left column (except on an event in the feed).

**Known bug**: This breaks the previous toggle functionality of items in the feed. You can no longer click an item again to deselect it. Lmk if you guys think this is an issue or if you prefer the new functionality.


![kapture 2019-02-09 at 15 39 45](https://user-images.githubusercontent.com/5913522/52526054-0eaaf900-2c81-11e9-96d7-480c95d55f1d.gif)
