### PR TITLE
Fix spacing asymmetry of arrows on small screens

### DIFF
--- a/src/components/home/selection/HomeSelectionWeekBar.css
+++ b/src/components/home/selection/HomeSelectionWeekBar.css
@@ -64,3 +64,10 @@
   border-left: 10px solid #D8D8D8;
   cursor: pointer;
 }
+
+@media (max-width: 800px) {
+  .HomeSelectionWeekBar .weekbar {
+    justify-content: space-around !important;
+    padding: 1em 0em !important;
+  }
+}


### PR DESCRIPTION
Tested on screens as small as iPhone 5/SE

Before:
![IMG_1924](https://user-images.githubusercontent.com/5913522/73130222-4f02a480-3fc2-11ea-9019-0bb755e154a8.jpeg)

After:
![IMG_1925](https://user-images.githubusercontent.com/5913522/73130224-5629b280-3fc2-11ea-982d-49875180967f.jpeg)
